### PR TITLE
Recognise Thank words as words

### DIFF
--- a/src/cogs/backgroundtasks.py
+++ b/src/cogs/backgroundtasks.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import re
 from utilities.helpers.utils import VoteReminder, Votelink, Suicide
 
-thank_words = "thanks|thank you|thank|ty"
+thank_words = "\bthanks\b|\bthank you\b|\bthank\b|\bty\b"
 
 class BackgroundTasks(commands.Cog):
     def __init__(self, bot: commands.Bot):


### PR DESCRIPTION
Recognise Thank words as words rather than string phrases by adding `\b` on both sides